### PR TITLE
Handle urls containing spaces

### DIFF
--- a/src/Bkwld/Croppa/Croppa.php
+++ b/src/Bkwld/Croppa/Croppa.php
@@ -149,6 +149,8 @@ class Croppa {
 	 * @return type
 	 */
 	static public function delete($url) {
+		// Need to decode the url so that we can handle things like space characters
+		$url = urldecode($url);
 	
 		// Delete the source image		
 		if (!($src = self::check_for_file($url))) {


### PR DESCRIPTION
Currently if you have an image with a space in the URL, say `my image.jpg`, the handle_404 function receives `$url` as `my%20image.jpg`.  This doesn't then match the image on the file system.  This fix decodes the URL first before looking for it in the file system.
