### PR TITLE
Update Croppa.php

### DIFF
--- a/src/Bkwld/Croppa/Croppa.php
+++ b/src/Bkwld/Croppa/Croppa.php
@@ -45,7 +45,8 @@ class Croppa {
 		
 		// Break the path apart and put back together again
 		$parts = pathinfo($src);
-		$url = $this->config['host'].$parts['dirname'].'/'.$parts['filename'].$suffix;
+		$parts['dirname'] = ltrim($parts['dirname'], '/');
+		$url = $this->config['host'].'/'. $parts['dirname'].'/'.$parts['filename'].$suffix;
 		if (!empty($parts['extension'])) $url .= '.'.$parts['extension'];
 		return $url;
 	}


### PR DESCRIPTION
Now we can pass `$src` parameter without first trailing slash.
For example, `Croppa::url('someimageonpublicdir.png', 200);`
