### PR TITLE
Support for Laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"require": {
 		"php": ">=5.3.0",
-		"illuminate/support": "<4.2,>=4.0",
+		"illuminate/support": "<4.3,>=4.0",
 		"weotch/PHPThumb": "~1.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
This fork allow Croppa to be installed on Laravel 4.2. Nothing fancy, just updated composer.json.
