### PR TITLE
Allows users to configure the PHP memory limit

### DIFF
--- a/src/Bkwld/Croppa/ServiceProvider.php
+++ b/src/Bkwld/Croppa/ServiceProvider.php
@@ -44,7 +44,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider {
 		$this->app->singleton('Bkwld\Croppa\Handler', function($app) {
 			return new Handler($app['Bkwld\Croppa\URL'],
 				$app['Bkwld\Croppa\Storage'],
-				$app['request']);
+				$app['request'],
+				$this->getConfig());
 		});
 
 		// Interact with the disk

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,5 +1,5 @@
 <?php return array(
-	
+
 	/*
 	|-----------------------------------------------------------------------------
 	| Image source and crop destination
@@ -7,30 +7,30 @@
 	*/
 
 	/**
-	 * The directory where source images are found. This is generally where your 
-	 * admin stores uploaded files. Can be either an absolute path to your local 
+	 * The directory where source images are found. This is generally where your
+	 * admin stores uploaded files. Can be either an absolute path to your local
 	 * disk (the default) or the name of an IoC binding of a Flysystem instance.
 	 *
 	 * @var string     Absolute path in local fileystem
-	 *      | string   IoC binding name of League\Flysystem\Filesystem 
+	 *      | string   IoC binding name of League\Flysystem\Filesystem
 	 *      | string   IoC binding name of League\Flysystem\Cached\CachedAdapter
 	 */
 	'src_dir' => public_path().'/uploads',
 
 	/**
-	 * The directory where cropped images should be saved. The route to the 
-	 * cropped versions is what should be rendered in your markup; it must be a 
+	 * The directory where cropped images should be saved. The route to the
+	 * cropped versions is what should be rendered in your markup; it must be a
 	 * web accessible directory.
 	 *
 	 * @var string     Absolute path in local fileystem
-	 *      | string   IoC binding name of League\Flysystem\Filesystem 
+	 *      | string   IoC binding name of League\Flysystem\Filesystem
 	 *      | string   IoC binding name of League\Flysystem\Cached\CachedAdapter
 	 */
 	'crops_dir' => public_path().'/uploads',
 
 	/**
-	 * Maximum number of sizes to allow for a particular source file. This is to 
-	 * limit scripts from filling up your hard drive with images. Set to false or 
+	 * Maximum number of sizes to allow for a particular source file. This is to
+	 * limit scripts from filling up your hard drive with images. Set to false or
 	 * comment out to have no limit. This is disabled by default because the
 	 * `signing_key` is a better prevention of malicious usage.
 	 *
@@ -46,14 +46,14 @@
 	*/
 
 	/**
-	 * A regex pattern that is applied to both the src url passed to 
+	 * A regex pattern that is applied to both the src url passed to
 	 * `Croppa::url()` as well as the crop path received when handling a crop
 	 * request to find the path to the src image relative to both the src_dir
-	 * and crops_dirs. This path will be used to find the source image in the 
-	 * src_dir. The path component of the regex must exist in the first captured 
+	 * and crops_dirs. This path will be used to find the source image in the
+	 * src_dir. The path component of the regex must exist in the first captured
 	 * subpattern. In other words, in the `preg_match` $matches[1].
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	'path' => 'uploads/(.*)$',
 
@@ -61,10 +61,10 @@
 	 * A regex pattern that works like `path` except it is only used by the
 	 * `Croppa::url($url)` generator function. If the $path url matches, it is
 	 * passed through with no Croppa URL suffixes added. Thus, it will not be
-	 * cropped. This is designed, in particular, for animated gifs which lose 
+	 * cropped. This is designed, in particular, for animated gifs which lose
 	 * animation when cropped.
-	 * 
-	 * @var string 
+	 *
+	 * @var string
 	 */
 	'ignore' => '\.(gif|GIF)$',
 
@@ -76,18 +76,25 @@
 	// 'url_prefix' => 'https://your-bucket.s3.amazonaws.com/uploads/', // S3
 
 	/**
-	 * Reject attempts to maliciously create images by signing the generated 
-	 * request with a hash based on the request parameters and this signing key. 
-	 * Set to 'app.key' to use Laravel's `app.key` config, any other string to use 
+	 * Reject attempts to maliciously create images by signing the generated
+	 * request with a hash based on the request parameters and this signing key.
+	 * Set to 'app.key' to use Laravel's `app.key` config, any other string to use
 	 * THAT as the key, or false to disable.
 	 *
-	 * If you are generating URLs outside of `Croppa::url()`, like the croppa.js 
-	 * module, you can disable this feature by setting the `signing_key` config 
+	 * If you are generating URLs outside of `Croppa::url()`, like the croppa.js
+	 * module, you can disable this feature by setting the `signing_key` config
 	 * to false.
 	 *
 	 * @var string|boolean
 	 */
 	'signing_key' => 'app.key',
+
+	/**
+	 * The PHP memory limit used by the script to generate thumbnails. Some
+	 * images require a lot of memory to perform the resize, so you may increase
+	 * this memory limit.
+	 */
+	'memory_limit' => '128M',
 
 	/*
 	|-----------------------------------------------------------------------------
@@ -96,9 +103,9 @@
 	*/
 
 	/**
-	 * The jpeg quality of generated images. The difference between 100 and 95 
-	 * usually cuts the file size in half. Going down to 70 looks ok on photos 
-	 * and will reduce filesize by more than another half but on vector files 
+	 * The jpeg quality of generated images. The difference between 100 and 95
+	 * usually cuts the file size in half. Going down to 70 looks ok on photos
+	 * and will reduce filesize by more than another half but on vector files
 	 * there is noticeable aliasing.
 	 *
 	 * @var integer
@@ -119,5 +126,5 @@
 	 * @var boolean
 	 */
 	'upscale' => false,
-	
+
 );


### PR DESCRIPTION
I have a project where I need to generate thumbnails for images up to 4000x4000 pixels. In those extreme cases, the hardcoded memory limit of 128M is exceed.