### PR TITLE
Use a simple array, fix #134

### DIFF
--- a/src/Bkwld/Croppa/Handler.php
+++ b/src/Bkwld/Croppa/Handler.php
@@ -117,9 +117,9 @@ class Handler extends Controller {
 		);
 
 		return [
-			'remote_crops' => $remote_crops,
-			'crop_path' => $crop_path,
-			'path' => $path,
+			$remote_crops,
+			$crop_path,
+			$path,
 		];
 
 	}


### PR DESCRIPTION
Since list() doesn't accept associative array, there's no point using one here.