### PR TITLE
Provided a way to bind without Laravel-Flysystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ App::singleton('s3', function($app) {
 	return $app['flysystem']->connection();
 });
 
+// Or alternatively, without the Laravel-Flysystem package
+App::singleton('s3', function () {
+    return Storage::disk('s3')->getDriver();
+});
+
 // Croppa config.php
 return [
 	'src_dir' => 's3',


### PR DESCRIPTION
Hello,

I've simply provided a way to make an IoC binding without the need for the whole Laravel Flysystem package. I wasn't using that package, and I didn't want to install an additional dependency just for binding. 

This way, you won't be needing the whole requirement just for this.

Thanks in advance,