### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/TestDelete.php
+++ b/tests/TestDelete.php
@@ -3,8 +3,9 @@
 use Bkwld\Croppa\Helpers;
 use Bkwld\Croppa\Storage;
 use Bkwld\Croppa\URL;
+use PHPUnit\Framework\TestCase;
 
-class TestDelete extends PHPUnit_Framework_TestCase {
+class TestDelete extends TestCase {
 
 	public function testDeleteSrc() {
 

--- a/tests/TestListAllCrops.php
+++ b/tests/TestListAllCrops.php
@@ -2,8 +2,9 @@
 
 use Bkwld\Croppa\Storage;
 use Bkwld\Croppa\URL;
+use PHPUnit\Framework\TestCase;
 
-class TestListAllCrops extends PHPUnit_Framework_TestCase {
+class TestListAllCrops extends TestCase {
 
 	public function setUp() {
 

--- a/tests/TestResizing.php
+++ b/tests/TestResizing.php
@@ -1,8 +1,9 @@
 <?php
 
 use Bkwld\Croppa\Image;
+use PHPUnit\Framework\TestCase;
 
-class TestResizing extends PHPUnit_Framework_TestCase {
+class TestResizing extends TestCase {
 
 	private $src;
 

--- a/tests/TestTooManyCrops.php
+++ b/tests/TestTooManyCrops.php
@@ -1,11 +1,12 @@
 <?php
 
 use Bkwld\Croppa\Storage;
+use PHPUnit\Framework\TestCase;
 
-class TestTooManyCrops extends PHPUnit_Framework_TestCase {
+class TestTooManyCrops extends TestCase {
 
 	private $dir;
-	
+
 	public function setUp() {
 
 		// Mock flysystem

--- a/tests/TestUrlGenerator.php
+++ b/tests/TestUrlGenerator.php
@@ -1,8 +1,9 @@
 <?php
 
 use Bkwld\Croppa\URL;
+use PHPUnit\Framework\TestCase;
 
-class TestUrlGenerator extends PHPUnit_Framework_TestCase {
+class TestUrlGenerator extends TestCase {
 
 	public function testWidthAndHeight() {
 		$url = new URL();

--- a/tests/TestUrlMatching.php
+++ b/tests/TestUrlMatching.php
@@ -1,8 +1,9 @@
 <?php
 
 use Bkwld\Croppa\URL;
+use PHPUnit\Framework\TestCase;
 
-class TestUrlMatching extends PHPUnit_Framework_TestCase {
+class TestUrlMatching extends TestCase {
 
 	private $url;
 	public function setUp() {

--- a/tests/TestUrlParsing.php
+++ b/tests/TestUrlParsing.php
@@ -1,8 +1,9 @@
 <?php
 
 use Bkwld\Croppa\URL;
+use PHPUnit\Framework\TestCase;
 
-class TestUrlParsing extends PHPUnit_Framework_TestCase {
+class TestUrlParsing extends TestCase {
 
 	private $url;
 	public function setUp() {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).