### PR TITLE
Update URL.php

### DIFF
--- a/src/Bkwld/Croppa/URL.php
+++ b/src/Bkwld/Croppa/URL.php
@@ -18,7 +18,7 @@ class URL {
      *
      * @var array
      */
-    private $config;
+    protected $config;
 
     /**
      * Inject dependencies


### PR DESCRIPTION
I use the cloud to store source and crops images, but Croppa :: url (), unfortunately, does not render, but only creates a link to crops of the image. Therefore, I am trying to expand the package for this. But I was faced with the fact that the package uses the "private" visibility zone for the config, which does not allow expanding it.

With this pull, I suggest changed to "protected" config for future use in extensible classes.

Also, maybe I can offer to add rendering in the absence of a file through Croppa :: url ()?