### PR TITLE
Fix the exif_read_data error with PHP 8

### DIFF
--- a/src/Bkwld/Croppa/Image.php
+++ b/src/Bkwld/Croppa/Image.php
@@ -62,8 +62,11 @@ class Image {
      * @return $this
      */
     public function autoRotate() {
-        $this->thumb->rotateJpg();
-        return $this;
+        try {
+            $this->thumb->rotateJpg();
+        } finally {
+            return $this;
+        }
     }
 
     /**


### PR DESCRIPTION
Related to #196.

Since the @ opperator doesn't suppress the new `ValueError` exception in PHP 8 (which by the way doesn't inherit from the `Exception` class), this PR fixes the issue by producing the same effect.