### PR TITLE
Fix pathToUrl first argument when using s3

### DIFF
--- a/src/Bkwld/Croppa/Handler.php
+++ b/src/Bkwld/Croppa/Handler.php
@@ -63,7 +63,7 @@ class Handler extends Controller {
 
         // Redirect to remote crops ...
         if ($this->storage->cropsAreRemote()) {
-            return new RedirectResponse($this->url->pathToUrl($crop_path), 301);
+            return new RedirectResponse($this->url->pathToUrl($request), 301);
 
         // ... or echo the image data to the browser
         } else {


### PR DESCRIPTION
I set my configs like this:

1) Laravel filesystem configured to use s3: `FILESYSTEM_DRIVER=s3` 

2) Croppa config

```
'src_dir' => 's3',
'crops_dir' => 's3',
'url_prefix' => 'https://<my-bucket>.s3.<my-region>.amazonaws.com/'
```

The only way I could make this to work was changing `pathToUrl` method first argument. I think the problem is because the `relativePath` ends up being called twice. First in the render method and after in the `pathToUrl` method again.

If my configs are right this change fix the problem.