### PR TITLE
Use tmp_disk for correct EXIF image rotation of remote images.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -19,6 +19,15 @@ return [
     'crops_disk' => 'public',
 
     /*
+     * The (optional) disk where remote source images are temporarily copied 
+     * to allow correct EXIF image rotation to occur.
+     * (The Intervention Image library can't correctly orientate remote images -
+     * see: https://image.intervention.io/v2/api/orientate)
+     * Set to false/null/empty-string to disable.
+     */
+    'tmp_disk' => 'public',
+
+    /*
      * Maximum number of sizes to allow for a particular source file. This is to
      * limit scripts from filling up your hard drive with images. Set to false or
      * comment out to have no limit. This is disabled by default because the


### PR DESCRIPTION
Croppa does not correctly rotate images from remote source disks due to an EXIF limitation of the Intervention Image Library (which is unable to correctly orientate remote images).

See limitation: https://image.intervention.io/v2/api/orientate

This pull request fixes issue: https://github.com/BKWLD/croppa/issues/112

This pull request utilises an optional tmp_disk to allow files to be copied locally so that the correct EXIF image rotations can occur.