### PR TITLE
Feautre/flexible thumbnail formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ composer.lock
 /node_modules
 /yarn.lock
 .idea
+
+### PHPUnit ###
+# Covers PHPUnit
+# Reference: https://phpunit.de/
+
+# Generated files
+.phpunit.result.cache
+.phpunit.cache
+

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ These are the arguments that Croppa::url() takes:
   - `quality($int)` - Set the jpeg compression quality from 0 to 100.
   - `interlace($bool)` - Set to `1` or `0` to turn interlacing on or off
   - `upsize($bool)` - Set to `1` or `0` to allow images to be upsized. If falsey and you ask for a size bigger than the source, it will **only** create an image as big as the original source.
+  - `format($string)` - Set the output format. Supported formats are: `jpg`, `jpeg`, `png`, `gif`, `webp`. If omitted, the format will be determined by the source image.
 
 #### Croppa::render($cropurl)
 

--- a/config/config.php
+++ b/config/config.php
@@ -95,7 +95,7 @@ return [
     'quality' => 95,
 
     /*
-     * Turn on interlacing to make progessive jpegs.
+     * Turn on interlacing to make progressive jpegs.
      *
      * @var boolean
      */
@@ -108,6 +108,18 @@ return [
      * @var boolean
      */
     'upsize' => false,
+
+    /**
+     * The default format for the generated image.
+     * - null: use the same format as the source image
+     * - 'jpg': force the format to jpg
+     * - 'png': force the format to png
+     * - 'gif': force the format to gif
+     * - 'webp': force the format to webp
+     *
+     * @var null|string
+     */
+    'format' => null,
 
     /*
      * Filters for adding additional GD effects to an image and using them as parameter

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Bkwld\Croppa;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Container\Container;
+
+class Config
+{
+    protected Application|Container $app;
+
+    public function __construct(Application|Container $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Get the configuration.
+     *
+     * @return array
+     * @throws BindingResolutionException
+     */
+    public function get(): array
+    {
+        $config = $this->app->make('config')->get('croppa');
+
+        // Use Laravel’s encryption key if instructed to.
+        if (
+            isset($config['signing_key']) &&
+            $config['signing_key'] === 'app.key'
+        ) {
+            $config['signing_key'] = $this->app->make('config')->get('app.key');
+        }
+
+        return $config;
+    }
+}

--- a/src/CroppaServiceProvider.php
+++ b/src/CroppaServiceProvider.php
@@ -67,7 +67,7 @@ class CroppaServiceProvider extends ServiceProvider
      * @return array
      * @throws BindingResolutionException
      */
-    protected function getConfig(): array
+    public function getConfig(): array
     {
         return $this->croppaConfig->get();
     }

--- a/src/CroppaServiceProvider.php
+++ b/src/CroppaServiceProvider.php
@@ -3,10 +3,19 @@
 namespace Bkwld\Croppa;
 
 use Bkwld\Croppa\Commands\Purge;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\ServiceProvider;
 
 class CroppaServiceProvider extends ServiceProvider
 {
+    protected Config $croppaConfig;
+
+    public function __construct($app)
+    {
+        parent::__construct($app);
+        $this->croppaConfig = new Config($this->app);
+    }
+
     public function register()
     {
         // Bind the Croppa URL generator and parser.
@@ -56,16 +65,10 @@ class CroppaServiceProvider extends ServiceProvider
      * Get the configuration.
      *
      * @return array
+     * @throws BindingResolutionException
      */
-    public function getConfig()
+    protected function getConfig(): array
     {
-        $config = $this->app->make('config')->get('croppa');
-
-        // Use Laravel’s encryption key if instructed to.
-        if (isset($config['signing_key']) && $config['signing_key'] === 'app.key') {
-            $config['signing_key'] = $this->app->make('config')->get('app.key');
-        }
-
-        return $config;
+        return $this->croppaConfig->get();
     }
 }

--- a/src/Image.php
+++ b/src/Image.php
@@ -167,7 +167,7 @@ class Image
     public function cropQuadrant(?int $width, ?int $height, array $options): self
     {
         if (!$height || !$width) {
-            throw new Exception('Croppa: Qudrant option needs width and height');
+            throw new Exception('Croppa: Quadrant option needs width and height');
         }
         if (empty($options['quadrant'][0])) {
             throw new Exception('Croppa:: No quadrant specified');
@@ -224,6 +224,7 @@ class Image
     /**
      * Pad an image to desired dimensions.
      * Moves and resize the image into the center and fills the rest with given color.
+     * @throws Exception
      */
     public function pad(?int $width, ?int $height, array $options): self
     {

--- a/src/Image.php
+++ b/src/Image.php
@@ -67,7 +67,7 @@ class Image
     }
 
     /**
-     * Turn on interlacing to make progessive JPEG files.
+     * Turn on interlacing to make progressive JPEG files.
      */
     public function interlace(): self
     {
@@ -245,7 +245,7 @@ class Image
     }
 
     /**
-     * Apply filters that have been defined in the config as seperate classes.
+     * Apply filters that have been defined in the config as separate classes.
      */
     public function applyFilters(array $options): self
     {
@@ -260,19 +260,12 @@ class Image
 
     private function getFormatFromPath(string $path): string
     {
-        switch (pathinfo($path, PATHINFO_EXTENSION)) {
-            case 'gif':
-                return 'gif';
-
-            case 'png':
-                return 'png';
-
-            case 'webp':
-                return 'webp';
-
-            default:
-                return 'jpg';
-        }
+        return match (pathinfo($path, PATHINFO_EXTENSION)) {
+            'gif' => 'gif',
+            'png' => 'png',
+            'webp' => 'webp',
+            default => 'jpg',
+        };
     }
 
     /**

--- a/src/ParameterBucket.php
+++ b/src/ParameterBucket.php
@@ -2,6 +2,11 @@
 
 namespace Bkwld\Croppa;
 
+/**
+ * A container for the parameters that are passed to the Croppa route.
+ * This is a value object.
+ * It is immutable.
+ */
 class ParameterBucket
 {
     protected string $path;

--- a/src/ParameterBucket.php
+++ b/src/ParameterBucket.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Bkwld\Croppa;
+
+class ParameterBucket
+{
+    protected string $path;
+    protected ?int $width;
+    protected ?int $height;
+    protected array $urlOptions;
+    protected URL|null $urlHelper;
+
+    public function __construct(
+        string $path,
+        ?int $width,
+        ?int $height,
+        array $urlOptions
+    )
+    {
+        $this->path = $path;
+        $this->width = $width;
+        $this->height = $height;
+        $this->urlOptions = $urlOptions;
+    }
+
+    /**
+     * @param string $requestPath
+     * @return static|null
+     * @throws Exception
+     */
+    public static function createFrom(string $requestPath): ?static
+    {
+        $url = app(URL::class);
+        $params = $url->parse($requestPath);
+
+        if (!$params) {
+            return null;
+        }
+
+        [$path, $width, $height, $options] = $params;
+
+        return new self(
+            $path,
+            $width,
+            $height,
+            $options
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getWidth(): ?int
+    {
+        return $this->width;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getHeight(): ?int
+    {
+        return $this->height;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUrlOptions(): array
+    {
+        return $this->urlOptions;
+    }
+
+    /**
+     * Take options in the URL and options from the config file
+     * and produce a config array.
+     */
+    public function config(): array
+    {
+        return $this->getUrlHelper()->config($this->getUrlOptions());
+    }
+
+    protected function getUrlHelper() {
+        $this->urlHelper = $this->urlHelper ?? app(URL::class);
+        return $this->urlHelper;
+    }
+}

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Bkwld\Croppa;
+
+class Renderer
+{
+    protected URL $url;
+    protected Storage $storage;
+    protected ?array $config;
+
+    /**
+     * @param URL $url
+     * @param Storage $storage
+     * @param array|null $config
+     */
+    public function __construct(
+        URL $url,
+        Storage $storage,
+        ?array $config = null
+    )
+    {
+        $this->url = $url;
+        $this->storage = $storage;
+        $this->config = $config;
+    }
+
+    /**
+     * Render image. Return the path to the crop relative to the storage disk.
+     * @param string $requestPath
+     * @return string|null
+     * @throws Exception
+     */
+    public function render(string $requestPath): ?string
+    {
+        $params = ParameterBucket::createFrom($requestPath);
+        $urlOptions = $params?->getUrlOptions() ?? [];
+        $configOptions = $this->url->config($urlOptions);
+
+        $cropPath = $this->getRelativeCropPath(
+            $requestPath,
+            $configOptions
+        );
+
+        if ($this->shouldReturnExistingCrop($cropPath)) {
+            return $cropPath;
+        }
+
+        if (!$params) {
+            return null;
+        }
+
+        $this->checkCropLimit($params->getPath());
+        $this->increaseMemoryLimitIfNeeded();
+        $image = $this->buildImage($params);
+        $this->processAndWriteImage($image, $cropPath, $params);
+
+        return $cropPath;
+    }
+
+    /**
+     * Get crop path relative to its directory.
+     * @throws Exception
+     */
+    public function getRelativeCropPath(
+        string $requestPath,
+        array $options
+    ): string
+    {
+        $relativePath = $this->url->relativePath($requestPath);
+
+        $format = data_get($options, 'format');
+
+        if ($format) {
+            $relativePath = $this->replaceOriginalFileSuffix(
+                $relativePath,
+                $format
+            );
+        }
+
+        return $relativePath;
+    }
+
+    public function replaceOriginalFileSuffix(
+        string $path,
+        string $suffix
+    ): string
+    {
+        $dirname = pathinfo($path, PATHINFO_DIRNAME);
+        $fileName = pathinfo($path, PATHINFO_FILENAME);
+
+        return sprintf(
+            '%s/%s.%s',
+            $dirname,
+            $fileName,
+            $suffix
+        );
+    }
+
+    /**
+     * TODO: Shouldn't already existing crops be returned no matter if they are stored locally or remotely.
+     *  Is this intentional?
+     *  Think about it and change it if needed. @see self::render()
+     * Determine if the existing crop should be returned.
+     * @param string $cropPath
+     * @return bool
+     */
+    public function shouldReturnExistingCrop(string $cropPath): bool
+    {
+        return $this->storage->cropsAreRemote() &&
+            $this->storage->cropExists($cropPath);
+    }
+
+    /**
+     * Check if there are too many crops already.
+     * @param string $path
+     * @throws Exception
+     */
+    public function checkCropLimit(string $path): void
+    {
+        if ($this->storage->tooManyCrops($path)) {
+            throw new Exception('Croppa: Max crops');
+        }
+    }
+
+    /**
+     * Increase memory limit if needed.
+     */
+    public function increaseMemoryLimitIfNeeded(): void
+    {
+        if ($this->config['memory_limit'] !== null) {
+            ini_set('memory_limit', $this->config['memory_limit']);
+        }
+    }
+
+    /**
+     * Build a new image using fetched image data.
+     */
+    protected function buildImage(ParameterBucket $params): Image
+    {
+        return new Image(
+            $this->storage->path($params->getPath()),
+            $params->config()
+        );
+    }
+
+    /**
+     * Process the image and write its data to disk.
+     * @throws Exception
+     */
+    protected function processAndWriteImage(
+        Image $image,
+        string $cropPath,
+        ParameterBucket $params
+    ): void
+    {
+        $newImage = $image->process(
+            $params->getWidth(),
+            $params->getHeight(),
+            $params->getUrlOptions()
+        );
+
+        $this->storage->writeCrop(
+            $cropPath,
+            $newImage->get()
+        );
+    }
+}

--- a/src/URL.php
+++ b/src/URL.php
@@ -8,7 +8,7 @@ namespace Bkwld\Croppa;
 class URL
 {
     /**
-     * The pattern used to indetify a request path as a Croppa-style URL
+     * The pattern used to identify a request path as a Croppa-style URL
      * https://github.com/BKWLD/croppa/wiki/Croppa-regex-pattern.
      *
      * @return string
@@ -128,6 +128,7 @@ class URL
      * Parse a request path into Croppa instructions.
      *
      * @return array|bool
+     * @throws Exception
      */
     public function parse(string $request)
     {
@@ -146,6 +147,7 @@ class URL
     /**
      * Take a URL or path to an image and get the path relative to the src and
      * crops dirs by using the `path` config regex.
+     * @throws Exception
      */
     public function relativePath(string $url): string
     {
@@ -188,12 +190,16 @@ class URL
             unset($options['filters']);
         }
 
+        if (isset($options['format'])) {
+            $options['format'] = data_get($options, 'format.0');
+        }
+
         // Return new options array
         return $options;
     }
 
     /**
-     * Build filter class instancees.
+     * Build filter class instances.
      *
      * @return null|array Array of filter instances
      */

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bkwld\Croppa\Test;
+
+use Bkwld\Croppa\Config;
+use Illuminate\Contracts\Container\BindingResolutionException;
+
+class ConfigTest extends TestCase
+{
+    /**
+     * @throws BindingResolutionException
+     */
+    public function testGet()
+    {
+        $config = new Config($this->app);
+        $configArray = $config->get();
+        $this->assertIsArray($configArray);
+
+        $this->assertArrayHasKey('src_disk', $configArray);
+        $this->assertArrayHasKey('crops_disk', $configArray);
+        $this->assertArrayHasKey('path', $configArray);
+        $this->assertArrayHasKey('interlace', $configArray);
+        $this->assertArrayHasKey('filters', $configArray);
+    }
+}

--- a/tests/ParameterBucketTest.php
+++ b/tests/ParameterBucketTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Bkwld\Croppa\Test;
+
+use Bkwld\Croppa\Exception;
+use Bkwld\Croppa\Filters\BlackWhite;
+use Bkwld\Croppa\Filters\Blur;
+use Bkwld\Croppa\ParameterBucket;
+use Bkwld\Croppa\Test\Traits\BindsUrl;
+
+class ParameterBucketTest extends TestCase
+{
+    use BindsUrl;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->bindUrl();
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function testCreateFrom(): void
+    {
+        $bucket = ParameterBucket::createFrom(
+            'uploads/some/dir/file-200x100.jpg'
+        );
+        $this->assertEquals('some/dir/file.jpg', $bucket->getPath());
+        $this->assertEquals(200, $bucket->getWidth());
+        $this->assertEquals(100, $bucket->getHeight());
+        $this->assertEquals([], $bucket->getUrlOptions());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function testCreateFromWithFilter(): void
+    {
+        $bucket = ParameterBucket::createFrom(
+            'uploads/some/dir/file-200x100-filters(gray).jpg'
+        );
+        $this->assertEquals('some/dir/file.jpg', $bucket->getPath());
+        $this->assertEquals(200, $bucket->getWidth());
+        $this->assertEquals(100, $bucket->getHeight());
+        $this->assertEquals(['filters' => [new BlackWhite()]],
+            $bucket->getUrlOptions());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function testCreateFromWithMultipleFilters(): void
+    {
+        $bucket = ParameterBucket::createFrom(
+            'uploads/some/dir/file-200x100-filters(gray,blur).jpg'
+        );
+        $this->assertEquals('some/dir/file.jpg', $bucket->getPath());
+        $this->assertEquals(200, $bucket->getWidth());
+        $this->assertEquals(100, $bucket->getHeight());
+        $this->assertEquals(['filters' => [new BlackWhite(), new Blur()]],
+            $bucket->getUrlOptions());
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function testCreateFromWithMultipleFiltersAndOptions(): void
+    {
+        $bucket = ParameterBucket::createFrom(
+            'uploads/some/dir/file-200x100-filters(gray,blur)-quality(50).jpg'
+        );
+        $this->assertEquals('some/dir/file.jpg', $bucket->getPath());
+        $this->assertEquals(200, $bucket->getWidth());
+        $this->assertEquals(100, $bucket->getHeight());
+        $this->assertEquals(
+            [
+                'filters' => [new BlackWhite(), new Blur()],
+                'quality' => 50,
+            ],
+            $bucket->getUrlOptions()
+        );
+    }
+}

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Bkwld\Croppa\Test;
+
+use Bkwld\Croppa\Exception;
+use Bkwld\Croppa\Renderer;
+use Bkwld\Croppa\Storage;
+use Bkwld\Croppa\Test\Traits\BindsUrl;
+use Bkwld\Croppa\Test\Traits\GetsConfig;
+use Bkwld\Croppa\URL;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Http\UploadedFile;
+
+/**
+ *
+ */
+class RendererTest extends TestCase
+{
+    use BindsUrl;
+    use GetsConfig;
+
+    protected function generateFakeImage(): void
+    {
+        $fileName = 'test.png';
+        $file = UploadedFile::fake()
+            ->image($fileName, 100, 100);
+
+        $this->defaultDisk->putFileAs(
+            '/',
+            $file,
+            $fileName
+        );
+    }
+
+    /**
+     * @return void
+     * @throws BindingResolutionException
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->bindUrl();
+
+        $this->url = $this->app->make(URL::class);
+        $config = $this->getConfig();
+        $storage = new Storage($config);
+
+        $this->generateFakeImage();
+
+        $this->renderer = new Renderer(
+            $this->url,
+            $storage,
+            $config
+        );
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function testRender(): void
+    {
+        $url = $this->url->generate(
+            'uploads/test.png',
+            50,
+            50
+        );
+
+        $this->assertEquals(
+            'image/png',
+            $this->defaultDisk->mimeType('test.png')
+        );
+
+        $cropPath = $this->renderer->render($url);
+        $this->assertStringContainsString(
+            'test-50x50.png',
+            $cropPath
+        );
+
+        $this->assertTrue(
+            $this->defaultDisk->exists($cropPath)
+        );
+
+        $this->assertEquals(
+            'image/png',
+            $this->defaultDisk->mimeType($cropPath)
+        );
+    }
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function testRenderWithForcedJpegFormat(): void
+    {
+        $url = $this->url->generate(
+            'uploads/test.png',
+            50,
+            50,
+            ['format' => 'jpg']
+        );
+
+        $this->assertEquals(
+            'image/png',
+            $this->defaultDisk->mimeType('test.png')
+        );
+
+        $cropPath = $this->renderer->render($url);
+        $this->assertStringContainsString(
+            'test-50x50-format(jpg).jpg',
+            $cropPath
+        );
+
+        $this->assertTrue(
+            $this->defaultDisk->exists($cropPath)
+        );
+
+        $this->assertEquals(
+            'image/jpeg',
+            $this->defaultDisk->mimeType($cropPath)
+        );
+    }
+
+    /**
+     * When crops are not remote, they are always rendered and stored
+     * @return void
+     * @throws Exception
+     */
+    public function testShouldNotReturnExistingCrop(): void
+    {
+        $url = $this->url->generate(
+            'uploads/test.png',
+            50,
+            50,
+            ['format' => 'jpg']
+        );
+        $cropPath = $this->renderer->render($url);
+
+        $this->assertFalse(
+            $this->renderer->shouldReturnExistingCrop($cropPath)
+        );
+    }
+
+    public function testReplaceOriginalFileSuffix(): void
+    {
+        $url = 'uploads/test.png';
+
+        $this->assertEquals(
+            'uploads/test.jpg',
+            $this->renderer->replaceOriginalFileSuffix($url, 'jpg')
+        );
+
+        $url = 'uploads/test.jpg.png';
+
+        $this->assertEquals(
+            'uploads/test.jpg.jpg',
+            $this->renderer->replaceOriginalFileSuffix($url, 'jpg')
+        );
+
+        $url = 'uploads/test.jpg.jpg';
+
+        $this->assertEquals(
+            'uploads/test.jpg.jpg',
+            $this->renderer->replaceOriginalFileSuffix($url, 'jpg')
+        );
+
+        $url = $this->url->generate(
+            'uploads/test.png',
+            50,
+            50,
+            ['format' => 'jpg']
+        );
+
+        $this->assertStringContainsString(
+            'uploads/test-50x50-format(jpg).jpg',
+            $this->renderer->replaceOriginalFileSuffix($url, 'jpg')
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Bkwld\Croppa\Test;
+
+use Bkwld\Croppa\CroppaServiceProvider;
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Storage as IlluminateStorage;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+abstract class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected Filesystem $defaultDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        $this->cleanDisk();
+        parent::tearDown();
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            CroppaServiceProvider::class,
+        ];
+    }
+
+    /**
+     * @param Application $app
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function getEnvironmentSetUp($app): void
+    {
+        $this->setUpTemporaryDisk($app);
+    }
+
+    /**
+     * @param Application $app
+     * @return void
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    protected function setUpTemporaryDisk(Application $app): void
+    {
+        /** @var Repository|Application|mixed $config */
+        $config = $app->get('config');
+        // Configure a fake_disk disk
+        $config->set('filesystems.disks.fake_disk', [
+            'driver' => 'local',
+            'root' => storage_path('app/fake-disk'),
+            'throw' => false,
+        ]);
+
+        // Set the default disk to the fake_disk disk
+        $config->set('filesystems.default', 'fake_disk');
+
+        $this->defaultDisk = IlluminateStorage::disk('fake_disk');
+        $app->singleton('fake_disk', function () {
+            return $this->defaultDisk;
+        });
+    }
+
+
+    protected function cleanDisk() {
+        $this->defaultDisk->deleteDirectory('/');
+    }
+}

--- a/tests/TestDelete.php
+++ b/tests/TestDelete.php
@@ -108,13 +108,21 @@ class TestDelete extends TestCase
         return new Helpers($url, $storage, $handler);
     }
 
-    public function testDeleteCropsInSubDir()
+    /**
+     * @return void
+     * @doesNotPerformAssertions
+     */
+    public function testDeleteCropsInSubDir(): void
     {
         $helpers = $this->mockHelpersForDeleting();
         $helpers->delete('/uploads/me.jpg');
     }
 
-    public function testDeleteCropsInSubDirWithFullURL()
+    /**
+     * @return void
+     * @doesNotPerformAssertions
+     */
+    public function testDeleteCropsInSubDirWithFullURL(): void
     {
         $helpers = $this->mockHelpersForDeleting();
         $helpers->delete('http://domain.com/uploads/me.jpg');

--- a/tests/TestUrlParsing.php
+++ b/tests/TestUrlParsing.php
@@ -102,4 +102,11 @@ class TestUrlParsing extends TestCase
             'file.jpg', 200, 100, [],
         ], $url->parse('images/crops/file-200x100.jpg'));
     }
+
+    public function testFormat()
+    {
+        $this->assertEquals([
+            '1/2/file.jpg', 200, 100, ['format' => 'png'],
+        ], $this->url->parse('uploads/1/2/file-200x100-format(png).jpg'));
+    }
 }

--- a/tests/Traits/BindsUrl.php
+++ b/tests/Traits/BindsUrl.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bkwld\Croppa\Test\Traits;
+
+use Bkwld\Croppa\URL;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @mixin TestCase
+ */
+trait BindsUrl
+{
+    use GetsConfig;
+
+    public function bindUrl(): void
+    {
+        app()->singleton(URL::class, function () {
+            return new URL($this->getConfig());
+        });
+    }
+}

--- a/tests/Traits/GetsConfig.php
+++ b/tests/Traits/GetsConfig.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bkwld\Croppa\Test\Traits;
+
+use Bkwld\Croppa\Config;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @mixin TestCase
+ */
+trait GetsConfig
+{
+    /**
+     * @throws BindingResolutionException
+     */
+    public function getConfig(): array
+    {
+        $app = app();
+        $config = new Config($app);
+        $configArray = $config->get();
+
+        $configArray['src_disk'] = 'fake_disk';
+        $configArray['crops_disk'] = 'fake_disk';
+        $configArray['path'] = 'uploads/(.*)$';
+
+        return $configArray;
+    }
+}


### PR DESCRIPTION
This pull request implements and documents a feature that allows setting the output format of the crops to a desired one among jpeg, webp, png and gif.

You can also see this issue: https://github.com/BKWLD/croppa/issues/212

This pull request also adds some tests to verify the feature works.
It also adds some functional tests that verify that Handler@handle works.

Some comment typos are also fixed.