### PR TITLE
Fix quality url parameter causing a type error

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -19,7 +19,7 @@ class Image
     /**
      * @var int
      */
-    private $quality;
+    private int $quality;
 
     /**
      * @var bool


### PR DESCRIPTION
This is a very tiny PR that fixes the following error when using "-quality(xx)" in the url (since [this commit](https://github.com/Intervention/image/pull/1323/files#diff-e48054c724cc294cdaf5ac93c44c9ea0cae6459676052edd679b2a4867b021ac) from `intervention/image`).

```
Intervention\Image\Encoders\JpegEncoder::__construct(): Argument #1 ($quality) must be of type int, 
string given, called in /var/www/html/vendor/intervention/image/src/Format.php on line 129
```

By typing the property to `int`, it ensures any `string` will be casted to an `int` (`"90"` becomes `90` and so on...).

I don't think it needs it's own test (at least not for this specific change), but feel free to ask if you think a dedicated test is necessary.