### PR TITLE
Add tmp_disk option/functionality to allow use of remote src_disk in Croppa 7.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 /node_modules
 /yarn.lock
 .idea
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ Thus, if you have `<img src="{{ Croppa::url('file.jpg', 200) }}">`, the returned
 
 #### Src images on S3, local crops
 
-This is a good solution for a load balanced enviornment. Each app server will end up with it’s own cache of cropped images, so there is some wasted space. But the web server (Apache, etc) can still serve the crops directly on subsequent crop requests.
+This is a good solution for a load balanced enviornment. Each app server will end up with it’s own cache of cropped images, so there is some wasted space. But the web server (Apache, etc) can still serve the crops directly on subsequent crop requests. A tmp_disk must also be defined to temporarily store the source image.
 
 ```php
 // Croppa config.php
 return [
     'src_disk' => 's3',
+    'tmp_disk' => 'temp',
     'crops_disk' => 'public',
     'path' => 'storage/(.*)$',
 ];

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Thus, if you have `<img src="{{ Croppa::url('file.jpg', 200) }}">`, the returned
 
 #### Src images on S3, local crops
 
-This is a good solution for a load balanced enviornment. Each app server will end up with it’s own cache of cropped images, so there is some wasted space. But the web server (Apache, etc) can still serve the crops directly on subsequent crop requests. A tmp_disk must also be defined to temporarily store the source image.
+This is a good solution for a load balanced environment. Each app server will end up with it’s own cache of cropped images, so there is some wasted space. But the web server (Apache, etc) can still serve the crops directly on subsequent crop requests. A tmp_disk must also be defined to temporarily store the source image.
 
 ```php
 // Croppa config.php

--- a/config/config.php
+++ b/config/config.php
@@ -19,12 +19,10 @@ return [
     'crops_disk' => 'public',
 
     /*
-     * The (optional) disk where remote source images are temporarily copied 
-     * to allow remote src_disk or correct EXIF image rotation to occur.
-     * Required if using a remote src_disk.
-     * (The Intervention Image library can't download or correctly orientate remote images -
-     * see: https://image.intervention.io/v3/introduction/upgrade
-     * and https://image.intervention.io/v2/api/orientate)
+     * If using a remote src_disk, a local disk must be specified where remote
+     * source images are temporarily copied.
+     * (The Intervention Image library can't download remote images -
+     * see: https://image.intervention.io/v3/introduction/upgrade)
      * Set to false/null/empty-string to disable.
      */
     'tmp_disk' => 'public',

--- a/config/config.php
+++ b/config/config.php
@@ -20,9 +20,11 @@ return [
 
     /*
      * The (optional) disk where remote source images are temporarily copied 
-     * to allow correct EXIF image rotation to occur.
-     * (The Intervention Image library can't correctly orientate remote images -
-     * see: https://image.intervention.io/v2/api/orientate)
+     * to allow remote src_disk or correct EXIF image rotation to occur.
+     * Required if using a remote src_disk.
+     * (The Intervention Image library can't download or correctly orientate remote images -
+     * see: https://image.intervention.io/v3/introduction/upgrade
+     * and https://image.intervention.io/v2/api/orientate)
      * Set to false/null/empty-string to disable.
      */
     'tmp_disk' => 'public',

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -160,7 +160,7 @@ final class Storage
                 return $srcDisk->path($path);
             }
 
-            // If the src_disk is a remote disk, and a tmp_disk has been configured, copy file to tmp_disk  - otherwise EXIF auto-rotation won't work)
+            // If a tmp_disk has been configured, copy file from remote srcDisk to tmpDisk
             if ($this->config['tmp_disk']) {
                 $tmpDisk = $this->getTmpDisk();
                 $tmpDisk->writeStream($path, $srcDisk->readStream($path));
@@ -168,6 +168,8 @@ final class Storage
                 return $tmpDisk->path($path);
             }
 
+            // With Intervention 3, this will lead to a DecoderException ("Unable to decode input")
+            // We should probably throw an exception here to inform the developer that a tmp_disk is required.
             return $srcDisk->url($path);
         }
 


### PR DESCRIPTION
I merged @miking7's PR https://github.com/BKWLD/croppa/pull/210 with latest updates to use a `tmp_disk` to allow remote `src_disk` to work with Intervention 3, which does not support remote files. I also updated some comments and the README to reflect the `tmp_disk` config option.

This resolves issue https://github.com/BKWLD/croppa/issues/223.

I'm not familiar enough with mocking to know how to mock a AwsS3V3Adapter or other remote disk, so no test is provided.